### PR TITLE
fix: EOL on windows conflicts with `yarn run prettier`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
possibly resolve #8.

Hi @zhicheng-ning, you could run

```bash
git clone -b fix/eol-on-windows git@github.com:tyn1998/sumi-devtools.git
```

to fresh clone this fix branch and test if things will still get bad.
